### PR TITLE
Fix compiling with '--no-default-features'

### DIFF
--- a/src/kanal_tests.rs
+++ b/src/kanal_tests.rs
@@ -1,25 +1,16 @@
-#[allow(dead_code)]
+#![allow(dead_code)]
+const MESSAGES: usize = 1000000;
+const THREADS: usize = 8;
+
 #[cfg(test)]
 mod tests {
-    use crate::{
-        bounded, bounded_async, unbounded, unbounded_async, AsyncReceiver, AsyncSender, Receiver,
-        Sender,
-    };
-
-    const MESSAGES: usize = 1000000;
-    const THREADS: usize = 8;
+    use crate::kanal_tests::{MESSAGES, THREADS};
+    use crate::{bounded, unbounded, Receiver, Sender};
 
     fn new<T>(cap: Option<usize>) -> (Sender<T>, Receiver<T>) {
         match cap {
             None => unbounded(),
             Some(cap) => bounded(cap),
-        }
-    }
-
-    fn new_async<T>(cap: Option<usize>) -> (AsyncSender<T>, AsyncReceiver<T>) {
-        match cap {
-            None => unbounded_async(),
-            Some(cap) => bounded_async(cap),
         }
     }
 
@@ -150,6 +141,19 @@ mod tests {
     #[test]
     fn mpmc_u() {
         mpmc(None);
+    }
+}
+#[cfg(feature = "async")]
+#[cfg(test)]
+mod async_tests {
+    use crate::kanal_tests::{MESSAGES, THREADS};
+    use crate::{bounded_async, unbounded_async, AsyncReceiver, AsyncSender};
+
+    fn new_async<T>(cap: Option<usize>) -> (AsyncSender<T>, AsyncReceiver<T>) {
+        match cap {
+            None => unbounded_async(),
+            Some(cap) => bounded_async(cap),
+        }
     }
 
     async fn async_mpmc(cap: Option<usize>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub struct Sender<T> {
 }
 
 // Async sender of channel for type T, it can generate sync version via clone_sync
+#[cfg(feature = "async")]
 pub struct AsyncSender<T> {
     internal: Internal<T>,
 }
@@ -102,6 +103,7 @@ impl<T> Drop for Sender<T> {
     }
 }
 
+#[cfg(feature = "async")]
 impl<T> Drop for AsyncSender<T> {
     fn drop(&mut self) {
         let mut internal = acquire_internal(&self.internal);
@@ -123,6 +125,7 @@ impl<T> Clone for Sender<T> {
     }
 }
 
+#[cfg(feature = "async")]
 impl<T> Clone for AsyncSender<T> {
     fn clone(&self) -> Self {
         let mut internal = acquire_internal(&self.internal);
@@ -325,6 +328,7 @@ impl<T> Sender<T> {
     }
 
     /// Clones Sender as async version of it and returns it
+    #[cfg(feature = "async")]
     pub fn clone_async(&self) -> AsyncSender<T> {
         let mut internal = acquire_internal(&self.internal);
         if internal.send_count > 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,14 +18,18 @@ pub(crate) mod state;
 
 use internal::{acquire_internal, ChannelInternal, Internal};
 
+#[cfg(feature = "async")]
+use std::mem::ManuallyDrop;
 use std::{
-    mem::{ManuallyDrop, MaybeUninit},
+    mem::MaybeUninit,
     time::{Duration, SystemTime},
 };
 
 use std::fmt;
 
-use signal::{AsyncSignal, SyncSignal};
+#[cfg(feature = "async")]
+use signal::AsyncSignal;
+use signal::SyncSignal;
 
 /*
 use crate::mutex::MutexGuard;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -39,7 +39,7 @@ unsafe impl<T> Send for AsyncSignal<T> {}
 #[derive(Default)]
 pub struct WakerStore(Mutex<Cell<Option<Waker>>>);
 
-#[allow(dead_code)]
+#[cfg(feature = "async")]
 impl WakerStore {
     pub fn register(&self, w: &Waker) {
         let waker = self.0.lock();

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,7 +1,10 @@
 use std::cell::Cell;
 
+#[cfg(feature = "async")]
 use std::future::Future;
+#[cfg(feature = "async")]
 use std::mem::ManuallyDrop;
+#[cfg(feature = "async")]
 use std::ptr::null_mut;
 
 use std::task::Waker;
@@ -36,6 +39,7 @@ unsafe impl<T> Send for AsyncSignal<T> {}
 #[derive(Default)]
 pub struct WakerStore(Mutex<Cell<Option<Waker>>>);
 
+#[allow(dead_code)]
 impl WakerStore {
     pub fn register(&self, w: &Waker) {
         let waker = self.0.lock();
@@ -49,6 +53,7 @@ impl WakerStore {
     }
 }
 
+#[cfg(feature = "async")]
 impl<T> Future for AsyncSignal<T> {
     type Output = u8;
     fn poll(
@@ -82,6 +87,7 @@ unsafe fn read_ptr<T>(ptr: *const T) -> T {
     }
 }
 
+#[cfg(feature = "async")]
 impl<T> AsyncSignal<T> {
     // signal to send data to a writer
     #[inline(always)]
@@ -273,6 +279,7 @@ impl<T> SyncSignal<T> {
 #[derive(Clone, Copy)]
 pub enum Signal<T> {
     Sync(*const SyncSignal<T>),
+    #[cfg(feature = "async")]
     Async(*const AsyncSignal<T>),
 }
 
@@ -284,6 +291,7 @@ impl<T> Signal<T> {
     pub unsafe fn wait(&self) -> bool {
         match self {
             Signal::Sync(sig) => (**sig).wait(),
+            #[cfg(feature = "async")]
             Signal::Async(_sig) => panic!("async sig: sync wait must not happen"),
         }
     }
@@ -291,6 +299,7 @@ impl<T> Signal<T> {
     pub unsafe fn wait_short(&self) -> u8 {
         match self {
             Signal::Sync(_sig) => panic!("sync sig: wait short must not happen"),
+            #[cfg(feature = "async")]
             Signal::Async(sig) => (**sig).wait_sync_short(),
         }
     }
@@ -298,6 +307,7 @@ impl<T> Signal<T> {
     pub unsafe fn send(self, d: T) {
         match self {
             Signal::Sync(sig) => SyncSignal::send(sig, d),
+            #[cfg(feature = "async")]
             Signal::Async(sig) => (&*sig).send(d),
         }
     }
@@ -305,6 +315,7 @@ impl<T> Signal<T> {
     pub unsafe fn recv(self) -> T {
         match self {
             Signal::Sync(sig) => SyncSignal::recv(sig),
+            #[cfg(feature = "async")]
             Signal::Async(sig) => (&*sig).recv(),
         }
     }
@@ -312,6 +323,7 @@ impl<T> Signal<T> {
     pub unsafe fn terminate(&self) {
         match self {
             Signal::Sync(sig) => SyncSignal::terminate(*sig),
+            #[cfg(feature = "async")]
             Signal::Async(sig) => (&**sig).terminate(),
         }
     }
@@ -321,7 +333,9 @@ impl<T> PartialEq for Signal<T> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Sync(l0), Self::Sync(r0)) => l0 == r0,
+            #[cfg(feature = "async")]
             (Self::Async(l0), Self::Async(r0)) => l0 == r0,
+            #[cfg(feature = "async")]
             _ => false,
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "async")]
+use std::time::Duration;
 use std::{
     sync::atomic::{AtomicU8, Ordering},
-    time::{Duration, SystemTime},
+    time::SystemTime,
 };
 
 /// State keeps state of signals in both sync and async to make eventing for senders and receivers possible
@@ -55,7 +57,7 @@ impl State {
         self.v.load(Ordering::SeqCst)
     }
 
-    #[allow(dead_code)]
+    #[cfg(feature = "async")]
     #[inline(always)]
     pub fn wait_indefinitely(&self) -> u8 {
         let v = self.v.load(Ordering::SeqCst);

--- a/src/state.rs
+++ b/src/state.rs
@@ -55,6 +55,7 @@ impl State {
         self.v.load(Ordering::SeqCst)
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     pub fn wait_indefinitely(&self) -> u8 {
         let v = self.v.load(Ordering::SeqCst);


### PR DESCRIPTION
Only part of the code was properly marked with the async cfg, thus failing when compiling with '--no-default-features'

This patch should add the cfg, all the missing places.