### PR TITLE
Fix typos

### DIFF
--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -93,20 +93,20 @@ pub fn randomize(d: usize) -> usize {
 
 // Static atomic variable used to store the degree of parallelism.
 // Initialized to 0, meaning that the parallelism degree has not been computed yet.
-static PARALELLISM: AtomicUsize = AtomicUsize::new(0);
+static PARALLELISM: AtomicUsize = AtomicUsize::new(0);
 
 // This function retrieves the available degree of parallelism.
-// If the degree of parallelism has not been computed yet, it computes and stores it in the PARALELLISM atomic variable.
+// If the degree of parallelism has not been computed yet, it computes and stores it in the PARALLELISM atomic variable.
 // The degree of parallelism typically corresponds to the number of processor cores that can execute threads concurrently.
 #[inline(always)]
 pub fn get_parallelism() -> usize {
-    let mut p = PARALELLISM.load(Ordering::Relaxed);
+    let mut p = PARALLELISM.load(Ordering::Relaxed);
     // If the parallelism degree has not been computed yet.
     if p == 0 {
         // Try to get the degree of parallelism from available_parallelism.
         // If it is not available, default to 1.
         p = usize::from(available_parallelism().unwrap_or(NonZeroUsize::new(1).unwrap()));
-        PARALELLISM.store(p, Ordering::SeqCst);
+        PARALLELISM.store(p, Ordering::SeqCst);
     }
     // Return the computed degree of parallelism.
     p

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,7 @@ macro_rules! shared_send_impl {
         /// Tries sending to the channel without waiting on the waitlist or
         /// channel internal lock. It returns `Ok(true)` in case of a successful
         /// operation and `Ok(false)` for a failed one, or error in case that
-        /// channel is closed. This function will `panic` on successfull send
+        /// channel is closed. This function will `panic` on successful send
         /// attempt of `None` data. Do not use this function unless you know
         /// exactly what you are doing.
         ///

--- a/src/oneshot.rs
+++ b/src/oneshot.rs
@@ -73,7 +73,7 @@ const FINISHED: *mut () = !0usize as *mut ();
 /// [`ActionResult`] translates state of compare_exchange off the AtomicPtr to
 /// more readable and easier to handle enum.
 enum ActionResult<T> {
-    /// Action was successfull
+    /// Action was successful
     Ok,
     /// State is racing, side can participate in race to win signal ptr
     Racing,
@@ -174,7 +174,7 @@ impl<T> OneshotInternal<T> {
     /// write to the signal as there will be multiple  mutable reference to
     /// signal, with this method channel resets state to racing if it's
     /// possible and tries to win the race again after updating the signal,
-    /// the logic is something similiar to the Mutex.
+    /// the logic is something similar to the Mutex.
     #[inline(always)]
     #[cfg(feature = "async")]
     fn try_reset(&self, own_ptr: *const Signal<T>) -> ActionResult<T> {
@@ -203,7 +203,7 @@ impl<T> OneshotInternal<T> {
     }
 }
 
-// Returns true if transfer was successfull.
+// Returns true if transfer was successful.
 #[inline(never)]
 fn try_drop_internal<T>(internal_ptr: OneshotInternalPointer<T>) -> bool {
     let internal = unsafe { internal_ptr.as_ref() };
@@ -514,7 +514,7 @@ impl<T> OneshotAsyncSender<T> {
     /// sending object as `Poll::ready(Err(T))`.
     pub fn send(self, data: T) -> OneshotSendFuture<T> {
         let internal_ptr = self.internal_ptr;
-        // No need to worry about droping the internal pointer in self, future
+        // No need to worry about dropping the internal pointer in self, future
         // is the new owner of the pointer.
         forget(self);
         if size_of::<T>() > size_of::<*mut T>() {
@@ -545,7 +545,7 @@ impl<T> OneshotAsyncReceiver<T> {
     /// consumes the receive side.
     pub fn recv(self) -> OneshotReceiveFuture<T> {
         let internal_ptr = self.internal_ptr;
-        // No need to worry about droping the internal pointer in self, future
+        // No need to worry about dropping the internal pointer in self, future
         // is the new owner of the pointer.
         forget(self);
         OneshotReceiveFuture {


### PR DESCRIPTION
Found few misspellings.
Only 1 in code.
