### PR TITLE
cancel safe

### DIFF
--- a/src/future.rs
+++ b/src/future.rs
@@ -235,15 +235,13 @@ impl<'a, T> Drop for ReceiveFuture<'a, T> {
                 if self.sig.async_blocking_wait() {
                     if let Poll::Ready(success) = self.sig.poll() {
                         if success {
-                            let data = unsafe {
-                                self.read_local_data()
-                            };
+                            let data = unsafe { self.read_local_data() };
                             internal.queue.push_front(data);
                             return;
                         }
                     }
                     drop(internal);
-                    
+
                     // got ownership of data that is not going to be used ever again, so drop it
                     if needs_drop::<T>() {
                         // Safety: data is not moved it's safe to drop it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,7 +489,9 @@ macro_rules! shared_send_impl {
 
         /// downgrade to WeakSender
         pub fn downgrade(&self) -> WeakSender<T> {
-            WeakSender { internal: self.internal.clone() }
+            WeakSender {
+                internal: self.internal.clone(),
+            }
         }
     };
 }
@@ -629,14 +631,15 @@ macro_rules! shared_recv_impl {
             internal.send_count == 0 && internal.queue.len() == 0
         }
 
-       
         /// create Sender from Receiver
         /// return None if Sender or Receiver is closed
         pub fn sender_sync(&self) -> Option<Sender<T>> {
             let mut internal = acquire_internal(&self.internal);
             if internal.send_count > 0 && internal.recv_count > 0 {
                 internal.send_count += 1;
-                return Some(Sender { internal: self.internal.clone() });
+                return Some(Sender {
+                    internal: self.internal.clone(),
+                });
             } else {
                 None
             }
@@ -649,12 +652,13 @@ macro_rules! shared_recv_impl {
             let mut internal = acquire_internal(&self.internal);
             if internal.send_count > 0 && internal.recv_count > 0 {
                 internal.send_count += 1;
-                return Some(AsyncSender { internal: self.internal.clone() });
+                return Some(AsyncSender {
+                    internal: self.internal.clone(),
+                });
             } else {
                 None
             }
         }
-        
     };
 }
 
@@ -1386,9 +1390,6 @@ impl<T> AsyncReceiver<T> {
         unsafe { transmute(self) }
     }
 
-
-    
-
     shared_impl!();
 }
 
@@ -1402,7 +1403,7 @@ impl<T> Drop for Receiver<T> {
                 if internal.send_count != 0 {
                     internal.terminate_signals();
                 }
-            } 
+            }
         }
     }
 }
@@ -1418,7 +1419,7 @@ impl<T> Drop for AsyncReceiver<T> {
                 if internal.send_count != 0 {
                     internal.terminate_signals();
                 }
-            } 
+            }
         }
     }
 }
@@ -1595,40 +1596,40 @@ pub fn unbounded_async<T>() -> (AsyncSender<T>, AsyncReceiver<T>) {
     )
 }
 
-/// 
+///
 pub struct WeakSender<T> {
     internal: Internal<T>,
 }
 
 impl<T> WeakSender<T> {
-    /// upgrade to Sender<T> 
+    /// upgrade to Sender<T>
     pub fn upgrade_sync(&self) -> Option<Sender<T>> {
         let mut internal = acquire_internal(&self.internal);
         if internal.send_count > 0 {
-
             internal.send_count += 1;
-            
-            Some(Sender { internal: self.internal.clone() })
+
+            Some(Sender {
+                internal: self.internal.clone(),
+            })
         } else {
             None
         }
-
     }
 
-    /// upgrade to AsyncSender<T> 
+    /// upgrade to AsyncSender<T>
     #[cfg(feature = "async")]
     pub fn upgrade_async(&self) -> Option<AsyncSender<T>> {
         let mut internal = acquire_internal(&self.internal);
         if internal.send_count > 0 {
-
             internal.send_count += 1;
-            
-            Some(AsyncSender { internal: self.internal.clone() })
+
+            Some(AsyncSender {
+                internal: self.internal.clone(),
+            })
         } else {
             None
         }
     }
-    
 }
 
 impl<T> fmt::Debug for WeakSender<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,6 +644,7 @@ macro_rules! shared_recv_impl {
 
         /// create Sender from Receiver
         /// return None if Sender or Receiver is closed
+        #[cfg(feature = "async")]
         pub fn sender_async(&self) -> Option<AsyncSender<T>> {
             let mut internal = acquire_internal(&self.internal);
             if internal.send_count > 0 && internal.recv_count > 0 {

--- a/src/oneshot.rs
+++ b/src/oneshot.rs
@@ -121,10 +121,7 @@ struct OneshotInternalPointer<T> {
 
 impl<T> Clone for OneshotInternalPointer<T> {
     fn clone(&self) -> Self {
-        Self {
-            ptr: self.ptr,
-            _phantom: PhantomData,
-        }
+        *self
     }
 }
 impl<T> Copy for OneshotInternalPointer<T> {}

--- a/tests/sync_test.rs
+++ b/tests/sync_test.rs
@@ -390,7 +390,6 @@ fn drop_test_in_signal() {
     .unwrap();
 }
 
-
 #[test]
 #[should_panic]
 fn create_sender_from_receiver_panic() {
@@ -411,7 +410,6 @@ fn create_sender_from_receiver_normal() {
     drop(tx);
 }
 
-
 #[test]
 fn weak_sender_normal() {
     let (tx, rx) = new::<i32>(None);
@@ -419,7 +417,6 @@ fn weak_sender_normal() {
     let weak = tx.downgrade();
 
     weak.upgrade_sync().unwrap();
-    
 }
 
 #[test]
@@ -431,7 +428,6 @@ fn weak_sender_panic() {
 
     drop(tx);
     weak.upgrade_sync().unwrap();
-    
 }
 
 #[test]
@@ -456,7 +452,6 @@ fn drop_all_elements() {
 
     assert_eq!(*NUMBER.read().unwrap(), 3);
 }
-
 
 #[test]
 fn vec_test() {


### PR DESCRIPTION
- add `WeakSender`
- support create `Sender` from `Receiver`
- make `AsyncReceiver::recv`  cancel safe in `tokio::select`
- clear internal queue immediately when all Receivers are dropped