### PR TITLE
Adds minimum supported rust version to cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kanal"
 version = "0.1.1"
 edition = "2021"
+rust-version = "1.81" #msrv
 authors = ["Khashayar Fereidani"]
 description = "The fast sync and async channel that Rust deserves"
 repository = "https://github.com/fereidani/kanal"
@@ -10,6 +11,7 @@ keywords = ["channel", "mpsc", "mpmc", "async"]
 categories = ["concurrency", "data-structures", "asynchronous"]
 license = "MIT"
 readme = "README.md"
+
 
 [dependencies]
 cacheguard = "0.1"


### PR DESCRIPTION
On older versions, compilation is failing with this error:

```
error[E0658]: use of unstable library feature 'error_in_core'
  --> /home/xtrm0/.cargo/registry/src/index.crates.io-6f17d22bba15001f/kanal-0.1.1/src/error.rs:14:6
   |
14 | impl core::error::Error for SendError {}
   |      ^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #103765 <https://github.com/rust-lang/rust/issues/103765> for more information

error[E0658]: use of unstable library feature 'error_in_core'
  --> /home/xtrm0/.cargo/registry/src/index.crates.io-6f17d22bba15001f/kanal-0.1.1/src/error.rs:39:6
   |
39 | impl core::error::Error for SendErrorTimeout {}
   |      ^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #103765 <https://github.com/rust-lang/rust/issues/103765> for more information

error[E0658]: use of unstable library feature 'error_in_core'
  --> /home/xtrm0/.cargo/registry/src/index.crates.io-6f17d22bba15001f/kanal-0.1.1/src/error.rs:63:6
   |
63 | impl core::error::Error for ReceiveError {}
   |      ^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #103765 <https://github.com/rust-lang/rust/issues/103765> for more information

error[E0658]: use of unstable library feature 'error_in_core'
  --> /home/xtrm0/.cargo/registry/src/index.crates.io-6f17d22bba15001f/kanal-0.1.1/src/error.rs:88:6
   |
88 | impl core::error::Error for ReceiveErrorTimeout {}
   |      ^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #103765 <https://github.com/rust-lang/rust/issues/103765> for more information

error[E0658]: use of unstable library feature 'error_in_core'
   --> /home/xtrm0/.cargo/registry/src/index.crates.io-6f17d22bba15001f/kanal-0.1.1/src/error.rs:105:6
    |
105 | impl core::error::Error for CloseError {}
    |      ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #103765 <https://github.com/rust-lang/rust/issues/103765> for more information
```