### PR TITLE
Support drain into blocking

### DIFF
--- a/src/future.rs
+++ b/src/future.rs
@@ -679,9 +679,7 @@ impl<T> Future for DrainIntoBlockingFuture<'_, '_, T> {
                 }
 
                 // Drain queue
-                while let Some(v) = internal.queue.pop_front() {
-                    this.vec.push(v);
-                }
+                this.vec.extend(internal.queue.drain(..));
 
                 // Drain wait_list send signals
                 while let Some(p) = internal.next_send() {

--- a/src/future.rs
+++ b/src/future.rs
@@ -581,3 +581,183 @@ impl<'a, 'b, T> Future for SendManyFuture<'a, 'b, T> {
         }
     }
 }
+
+/// DrainIntoBlockingFuture is a future for draining all available messages from a channel
+/// into a vector, blocking until at least one message is received.
+#[must_use = "futures do nothing unless you .await or poll them"]
+pub struct DrainIntoBlockingFuture<'a, 'b, T> {
+    internal: &'a Internal<T>,
+    sig: AsyncSignal<T>,
+    vec: &'b mut Vec<T>,
+    _pinned: PhantomPinned,
+}
+
+impl<T> Drop for DrainIntoBlockingFuture<'_, '_, T> {
+    fn drop(&mut self) {
+        let state = self.sig.state();
+        if unlikely(!state.is_done()) {
+            // try to cancel the signal if we are still waiting
+            if state.is_pending()
+                && acquire_internal(self.internal).cancel_recv_signal(self.sig.as_tagged_ptr())
+            {
+                // signal canceled
+                return;
+            }
+            // we failed to cancel the signal,
+            // either it is unregistered or a sender got signal ownership, receiver should
+            // wait until the response
+            if !state.is_unregistered() && self.sig.blocking_wait() {
+                // got ownership of data that is not going to be used ever again, so drop it
+                // SAFETY: data is not moved it's safe to drop it or put it back to the channel queue
+                unsafe {
+                    if self.internal.capacity() == 0 {
+                        #[cfg(debug_assertions)]
+                        println!(
+                            "warning: DrainIntoBlockingFuture dropped while send operation is in progress"
+                        );
+                        self.sig.drop_data();
+                    } else {
+                        // fallback: push it back to the channel queue
+                        acquire_internal(self.internal)
+                            .queue
+                            .push_front(self.sig.assume_init())
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<T> Debug for DrainIntoBlockingFuture<'_, '_, T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "DrainIntoBlockingFuture {{ .. }}")
+    }
+}
+
+impl<'a, 'b, T> DrainIntoBlockingFuture<'a, 'b, T> {
+    #[inline(always)]
+    pub(crate) fn new(internal: &'a Internal<T>, vec: &'b mut Vec<T>) -> Self {
+        Self {
+            sig: AsyncSignal::new_recv(),
+            internal,
+            vec,
+            _pinned: PhantomPinned,
+        }
+    }
+}
+
+impl<T> Future for DrainIntoBlockingFuture<'_, '_, T> {
+    type Output = Result<usize, ReceiveError>;
+
+    #[inline(always)]
+    fn poll(self: Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> Poll<Self::Output> {
+        let this = unsafe { self.get_unchecked_mut() };
+
+        match this.sig.state() {
+            FutureState::Unregistered => {
+                let vec_initial_length = this.vec.len();
+                let mut internal = acquire_internal(this.internal);
+
+                // Check if channel is closed
+                if unlikely(internal.recv_count == 0) {
+                    this.sig.set_state_relaxed(FutureState::Done);
+                    return Poll::Ready(Err(ReceiveError()));
+                }
+
+                // Calculate required capacity and reserve
+                let required_cap = internal.queue.len() + {
+                    if internal.recv_blocking {
+                        0
+                    } else {
+                        internal.wait_list.len()
+                    }
+                };
+                let remaining_cap = this.vec.capacity() - vec_initial_length;
+                if required_cap > remaining_cap {
+                    this.vec
+                        .reserve(vec_initial_length + required_cap - remaining_cap);
+                }
+
+                // Drain queue
+                while let Some(v) = internal.queue.pop_front() {
+                    this.vec.push(v);
+                }
+
+                // Drain wait_list send signals
+                while let Some(p) = internal.next_send() {
+                    // SAFETY: it's safe to receive from owned signal once
+                    unsafe { this.vec.push(p.recv()) }
+                }
+
+                // If got data, return immediately
+                let count = this.vec.len() - vec_initial_length;
+                if count > 0 {
+                    this.sig.set_state_relaxed(FutureState::Done);
+                    return Poll::Ready(Ok(count));
+                }
+
+                // No data, check if there are still senders
+                if unlikely(internal.send_count == 0) {
+                    this.sig.set_state_relaxed(FutureState::Done);
+                    return Poll::Ready(Err(ReceiveError()));
+                }
+
+                // Register signal and wait
+                this.sig.set_state(FutureState::Pending);
+                // SAFETY: waker is NOOP and not shared yet, it is safe to init it here
+                unsafe {
+                    this.sig.update_waker(cx.waker());
+                }
+                internal.push_signal(this.sig.dynamic_ptr());
+                drop(internal);
+                Poll::Pending
+            }
+            FutureState::Success => {
+                this.sig.set_state_relaxed(FutureState::Done);
+                // SAFETY: data is received and safe to read
+                this.vec.push(unsafe { this.sig.assume_init() });
+                Poll::Ready(Ok(1))
+            }
+            FutureState::Pending => {
+                let waker = cx.waker();
+                // SAFETY: signal waker is valid as we inited it in future pending state
+                if unsafe { !this.sig.will_wake(waker) } {
+                    // the Waker is changed and we need to update waker in the waiting list
+                    let internal = acquire_internal(this.internal);
+                    if internal.recv_signal_exists(this.sig.as_tagged_ptr()) {
+                        // SAFETY: signal is not shared with other thread yet so it's safe to
+                        // update waker locally
+                        unsafe {
+                            this.sig.update_waker(waker);
+                        }
+                        drop(internal);
+                        Poll::Pending
+                    } else {
+                        drop(internal);
+                        // the signal is already shared, and data will be available shortly,
+                        // so wait synchronously and return the result
+                        this.sig.set_state_relaxed(FutureState::Done);
+                        if likely(this.sig.blocking_wait()) {
+                            // SAFETY: data is received and safe to read
+                            this.vec.push(unsafe { this.sig.assume_init() });
+                            Poll::Ready(Ok(1))
+                        } else {
+                            Poll::Ready(Err(ReceiveError()))
+                        }
+                    }
+                } else {
+                    Poll::Pending
+                }
+            }
+            FutureState::Failure => {
+                mark_branch_unlikely();
+                this.sig.set_state_relaxed(FutureState::Done);
+                Poll::Ready(Err(ReceiveError()))
+            }
+            FutureState::Done => {
+                mark_branch_unlikely();
+                panic!("polled after result is already returned")
+            }
+        }
+    }
+}

--- a/src/future.rs
+++ b/src/future.rs
@@ -611,10 +611,6 @@ impl<T> Drop for DrainIntoBlockingFuture<'_, '_, T> {
                 // SAFETY: data is not moved it's safe to drop it or put it back to the channel queue
                 unsafe {
                     if self.internal.capacity() == 0 {
-                        #[cfg(debug_assertions)]
-                        println!(
-                            "warning: DrainIntoBlockingFuture dropped while send operation is in progress"
-                        );
                         self.sig.drop_data();
                     } else {
                         // fallback: push it back to the channel queue

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1198,9 +1198,7 @@ impl<T> Receiver<T> {
         }
 
         // Drain queue
-        while let Some(v) = internal.queue.pop_front() {
-            vec.push(v);
-        }
+        vec.extend(internal.queue.drain(..));
 
         // Drain wait_list send signals
         while let Some(p) = internal.next_send() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1167,6 +1167,79 @@ impl<T> Receiver<T> {
         // if the queue is not empty send the data
     }
 
+    /// Drains all available messages from the channel into the provided vector,
+    /// blocking until at least one message is received.
+    ///
+    /// This function combines the behavior of `drain_into` with blocking semantics:
+    /// - If messages are available, it drains all of them and returns immediately
+    /// - If no messages are available, it blocks until at least one message arrives
+    ///
+    /// Returns the number of messages received.
+    pub fn drain_into_blocking(&self, vec: &mut Vec<T>) -> Result<usize, ReceiveError> {
+        let vec_initial_length = vec.len();
+        let mut internal = acquire_internal(&self.internal);
+
+        // Check if channel is closed
+        if unlikely(internal.recv_count == 0) {
+            return Err(ReceiveError());
+        }
+
+        // Calculate required capacity and reserve
+        let required_cap = internal.queue.len() + {
+            if internal.recv_blocking {
+                0
+            } else {
+                internal.wait_list.len()
+            }
+        };
+        let remaining_cap = vec.capacity() - vec_initial_length;
+        if required_cap > remaining_cap {
+            vec.reserve(vec_initial_length + required_cap - remaining_cap);
+        }
+
+        // Drain queue
+        while let Some(v) = internal.queue.pop_front() {
+            vec.push(v);
+        }
+
+        // Drain wait_list send signals
+        while let Some(p) = internal.next_send() {
+            // SAFETY: it's safe to receive from owned signal once
+            unsafe { vec.push(p.recv()) }
+        }
+
+        // If got data, return immediately
+        let count = vec.len() - vec_initial_length;
+        if count > 0 {
+            return Ok(count);
+        }
+
+        // No data, check if there are still senders
+        if unlikely(internal.send_count == 0) {
+            return Err(ReceiveError());
+        }
+
+        // Register signal and wait
+        let mut ret = MaybeUninit::<T>::uninit();
+        let sig = pin!(SyncSignal::new(KanalPtr::new_write_address_ptr(
+            ret.as_mut_ptr()
+        )));
+        internal.push_signal(sig.dynamic_ptr());
+        drop(internal);
+
+        if unlikely(!sig.wait()) {
+            return Err(ReceiveError());
+        }
+
+        // Read data and return
+        if size_of::<T>() > size_of::<*mut T>() {
+            vec.push(unsafe { ret.assume_init() });
+        } else {
+            vec.push(unsafe { sig.assume_init() });
+        }
+        Ok(1)
+    }
+
     shared_recv_impl!();
     #[cfg(feature = "async")]
     /// Clones receiver as the async version of it
@@ -1316,6 +1389,23 @@ impl<T> AsyncReceiver<T> {
     pub fn stream(&'_ self) -> ReceiveStream<'_, T> {
         ReceiveStream::new_borrowed(self)
     }
+
+    /// Returns a [`DrainIntoBlockingFuture`] to drain all available messages from the channel
+    /// into the provided vector, blocking until at least one message is received.
+    ///
+    /// This function combines the behavior of `drain_into` with async blocking semantics:
+    /// - If messages are available, it drains all of them and returns immediately
+    /// - If no messages are available, it awaits until at least one message arrives
+    ///
+    /// Returns the number of messages received.
+    #[inline(always)]
+    pub fn drain_into_blocking<'a, 'b>(
+        &'a self,
+        vec: &'b mut Vec<T>,
+    ) -> DrainIntoBlockingFuture<'a, 'b, T> {
+        DrainIntoBlockingFuture::new(&self.internal, vec)
+    }
+
     shared_recv_impl!();
     /// Returns sync cloned version of the receiver.
     ///

--- a/tests/async_test.rs
+++ b/tests/async_test.rs
@@ -493,6 +493,131 @@ mod asyncs {
         drain_into_blocking(None).await;
     }
 
+    // Test that drain_into_blocking actually awaits when no data is available
+    async fn drain_into_blocking_waits(channel_size: Option<usize>) {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let (s, r) = new(channel_size);
+        let received = Arc::new(AtomicBool::new(false));
+        let received_clone = received.clone();
+
+        // Spawn receiver task that will await for data
+        let handle = tokio::spawn(async move {
+            let mut vec = Vec::new();
+            let count = r.drain_into_blocking(&mut vec).await.unwrap();
+            received_clone.store(true, Ordering::SeqCst);
+            assert!(count > 0);
+            vec
+        });
+
+        // Give receiver time to start awaiting
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        // Receiver should still be awaiting (no data sent yet)
+        assert!(
+            !received.load(Ordering::SeqCst),
+            "receiver should be awaiting"
+        );
+
+        // Now send data
+        s.send(42usize).await.unwrap();
+
+        // Wait for receiver to complete
+        let vec = handle.await.unwrap();
+        assert!(
+            received.load(Ordering::SeqCst),
+            "receiver should have received"
+        );
+        assert_eq!(vec, vec![42]);
+    }
+
+    #[tokio::test]
+    async fn drain_into_blocking_waits_0() {
+        drain_into_blocking_waits(Some(0)).await;
+    }
+
+    #[tokio::test]
+    async fn drain_into_blocking_waits_1() {
+        drain_into_blocking_waits(Some(1)).await;
+    }
+
+    #[tokio::test]
+    async fn drain_into_blocking_waits_u() {
+        drain_into_blocking_waits(None).await;
+    }
+
+    // Test drain_into_blocking with multiple concurrent senders
+    async fn drain_into_blocking_mpsc(channel_size: Option<usize>) {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        const NUM_SENDERS: usize = 10;
+        const MSGS_PER_SENDER: usize = 100;
+        const TOTAL_MSGS: usize = NUM_SENDERS * MSGS_PER_SENDER;
+
+        let (s, r) = new(channel_size);
+        let sent_count = Arc::new(AtomicUsize::new(0));
+
+        // Spawn multiple sender tasks
+        let handles: Vec<_> = (0..NUM_SENDERS)
+            .map(|sender_id| {
+                let s = s.clone();
+                let sent_count = sent_count.clone();
+                tokio::spawn(async move {
+                    for i in 0..MSGS_PER_SENDER {
+                        s.send(sender_id * MSGS_PER_SENDER + i).await.unwrap();
+                        sent_count.fetch_add(1, Ordering::SeqCst);
+                    }
+                })
+            })
+            .collect();
+
+        drop(s); // Drop original sender
+
+        // Receiver uses drain_into_blocking to collect all messages
+        let mut vec = Vec::new();
+        loop {
+            match r.drain_into_blocking(&mut vec).await {
+                Ok(count) => {
+                    assert!(count > 0);
+                    if vec.len() >= TOTAL_MSGS {
+                        break;
+                    }
+                }
+                Err(_) => break, // Channel closed
+            }
+        }
+
+        // Wait for all senders to complete
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        assert_eq!(vec.len(), TOTAL_MSGS);
+
+        // Verify all messages received (order may vary due to concurrency)
+        vec.sort();
+        for (i, v) in vec.iter().enumerate() {
+            assert_eq!(*v, i);
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_into_blocking_mpsc_0() {
+        drain_into_blocking_mpsc(Some(0)).await;
+    }
+
+    #[tokio::test]
+    async fn drain_into_blocking_mpsc_1() {
+        drain_into_blocking_mpsc(Some(1)).await;
+    }
+
+    #[tokio::test]
+    async fn drain_into_blocking_mpsc_u() {
+        drain_into_blocking_mpsc(None).await;
+    }
+
     #[tokio::test]
     async fn one_msg() {
         let (s, r) = bounded_async::<u8>(1);

--- a/tests/sync_test.rs
+++ b/tests/sync_test.rs
@@ -600,14 +600,20 @@ fn drain_into_blocking_waits(channel_size: Option<usize>) {
     std::thread::sleep(Duration::from_millis(50));
 
     // Receiver should still be blocked (no data sent yet)
-    assert!(!received.load(Ordering::SeqCst), "receiver should be blocking");
+    assert!(
+        !received.load(Ordering::SeqCst),
+        "receiver should be blocking"
+    );
 
     // Now send data
     s.send(42usize).unwrap();
 
     // Wait for receiver to complete
     let vec = handle.join().unwrap();
-    assert!(received.load(Ordering::SeqCst), "receiver should have received");
+    assert!(
+        received.load(Ordering::SeqCst),
+        "receiver should have received"
+    );
     assert_eq!(vec, vec![42]);
 }
 

--- a/tests/sync_test.rs
+++ b/tests/sync_test.rs
@@ -577,3 +577,122 @@ fn drain_into_blocking_1() {
 fn drain_into_blocking_u() {
     drain_into_blocking(None);
 }
+
+// Test that drain_into_blocking actually blocks when no data is available
+fn drain_into_blocking_waits(channel_size: Option<usize>) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    let (s, r) = new(channel_size);
+    let received = Arc::new(AtomicBool::new(false));
+    let received_clone = received.clone();
+
+    // Spawn receiver thread that will block waiting for data
+    let handle = std::thread::spawn(move || {
+        let mut vec = Vec::new();
+        let count = r.drain_into_blocking(&mut vec).unwrap();
+        received_clone.store(true, Ordering::SeqCst);
+        assert!(count > 0);
+        vec
+    });
+
+    // Give receiver time to start blocking
+    std::thread::sleep(Duration::from_millis(50));
+
+    // Receiver should still be blocked (no data sent yet)
+    assert!(!received.load(Ordering::SeqCst), "receiver should be blocking");
+
+    // Now send data
+    s.send(42usize).unwrap();
+
+    // Wait for receiver to complete
+    let vec = handle.join().unwrap();
+    assert!(received.load(Ordering::SeqCst), "receiver should have received");
+    assert_eq!(vec, vec![42]);
+}
+
+#[test]
+fn drain_into_blocking_waits_0() {
+    drain_into_blocking_waits(Some(0));
+}
+
+#[test]
+fn drain_into_blocking_waits_1() {
+    drain_into_blocking_waits(Some(1));
+}
+
+#[test]
+fn drain_into_blocking_waits_u() {
+    drain_into_blocking_waits(None);
+}
+
+// Test drain_into_blocking with multiple concurrent senders
+fn drain_into_blocking_mpsc(channel_size: Option<usize>) {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    const NUM_SENDERS: usize = 10;
+    const MSGS_PER_SENDER: usize = 100;
+    const TOTAL_MSGS: usize = NUM_SENDERS * MSGS_PER_SENDER;
+
+    let (s, r) = new(channel_size);
+    let sent_count = Arc::new(AtomicUsize::new(0));
+
+    // Spawn multiple sender threads
+    let handles: Vec<_> = (0..NUM_SENDERS)
+        .map(|sender_id| {
+            let s = s.clone();
+            let sent_count = sent_count.clone();
+            std::thread::spawn(move || {
+                for i in 0..MSGS_PER_SENDER {
+                    s.send(sender_id * MSGS_PER_SENDER + i).unwrap();
+                    sent_count.fetch_add(1, Ordering::SeqCst);
+                }
+            })
+        })
+        .collect();
+
+    drop(s); // Drop original sender
+
+    // Receiver uses drain_into_blocking to collect all messages
+    let mut vec = Vec::new();
+    loop {
+        match r.drain_into_blocking(&mut vec) {
+            Ok(count) => {
+                assert!(count > 0);
+                if vec.len() >= TOTAL_MSGS {
+                    break;
+                }
+            }
+            Err(_) => break, // Channel closed
+        }
+    }
+
+    // Wait for all senders to complete
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    assert_eq!(vec.len(), TOTAL_MSGS);
+
+    // Verify all messages received (order may vary due to concurrency)
+    vec.sort();
+    for (i, v) in vec.iter().enumerate() {
+        assert_eq!(*v, i);
+    }
+}
+
+#[test]
+fn drain_into_blocking_mpsc_0() {
+    drain_into_blocking_mpsc(Some(0));
+}
+
+#[test]
+fn drain_into_blocking_mpsc_1() {
+    drain_into_blocking_mpsc(Some(1));
+}
+
+#[test]
+fn drain_into_blocking_mpsc_u() {
+    drain_into_blocking_mpsc(None);
+}


### PR DESCRIPTION
Closes #60

## Summary

Add `drain_into_blocking` method for both sync and async receivers. This method drains all available messages into a vector, waiting until at least one message is received (unless the channel is closed).

## API

```rust
// Sync
impl<T> Receiver<T> {
    pub fn drain_into_blocking(&self, vec: &mut Vec<T>) -> Result<usize, ReceiveError>;
}

// Async
impl<T> AsyncReceiver<T> {
    pub fn drain_into_blocking(&self, vec: &mut Vec<T>) -> DrainIntoBlockingFuture<T>;
}
```

**Note**: For the async version, "blocking" refers to the semantic behavior (waiting for data), not thread blocking. The method is fully async and yields to the runtime.

## Implementation

### Why `drain_into` uses shared macro but `drain_into_blocking` doesn't

`drain_into` is **non-blocking** - it only retrieves currently available data and returns immediately. No waiting mechanism needed, so sync/async receivers share the same code via `shared_recv_impl!()` macro.

`drain_into_blocking` needs to **wait** when no data is available. Sync and async waiting mechanisms are fundamentally different:

| Aspect | Sync | Async |
|--------|------|-------|
| Signal | `SyncSignal` | `AsyncSignal` |
| Wait | `thread::park()` | `Poll::Pending` + `Waker` |
| Wake | `thread::unpark()` | `waker.wake()` |

This is the same pattern as `recv()` vs `ReceiveFuture`.

### Core Logic

1. Try drain all buffered messages (same as `drain_into`)
2. If got data → return immediately
3. If no data:
   - Check if channel closed → return error
   - Register signal to wait_list
   - Wait for sender to wake us
   - Return 1 (the received message)

## Files Changed

- `src/lib.rs`: Add `Receiver::drain_into_blocking` + `AsyncReceiver::drain_into_blocking` with doctest examples
- `src/future.rs`: Add `DrainIntoBlockingFuture` with `Future` and `Drop` impl
- `tests/sync_test.rs`: Add tests (basic, wait behavior, MPSC)
- `tests/async_test.rs`: Add tests (basic, wait behavior, MPSC)
