### PR TITLE
fix: prevent data loss in SendManyFuture on closed channel

### DIFF
--- a/src/future.rs
+++ b/src/future.rs
@@ -485,7 +485,7 @@ impl<'a, 'b, T> Future for SendManyFuture<'a, 'b, T> {
 
                 match fut.poll(cx) {
                     Poll::Ready(res) => {
-                        if this.elements.is_empty() {
+                        if res.is_err() || this.elements.is_empty() {
                             this.finished = true;
                             return Poll::Ready(res);
                         }


### PR DESCRIPTION
Hi, thanks for kanal!

When SendManyFuture polls its inner SendFuture and gets an error (channel closed), the error is silently dropped if there are remaining elements to send. The loop continues, rediscovers the closed channel, and returns a different element in the error — the original element is permanently lost.

The fix returns the error immediately regardless of whether there are remaining elements.